### PR TITLE
Refactor attack power handling

### DIFF
--- a/index.html
+++ b/index.html
@@ -211,7 +211,7 @@
 
     // ---------- Game State ----------
     const state = {
-      player: { atkBase: 10, critChance: 0.10, critMult: 2.0, gold: 0, ether: 0 },
+      player: { atkBase: 10, atk: 10, critChance: 0.10, critMult: 2.0, gold: 0, ether: 0 },
       upgrades: {
         atk:   { level: 1, baseCost: 30,  scale: 1.35 },
         crit:  { level: 0, baseCost: 50,  scale: 1.7  },
@@ -252,9 +252,11 @@
 
     // ---------- Save/Load (stable key + migration) ----------
     function save(){
+      const { atk, ...player } = state.player;
       const payload = {
         __version: VERSION,
-        player:state.player, upgrades:state.upgrades, floor:state.floor, highestFloor:state.highestFloor,
+        player,
+        upgrades:state.upgrades, floor:state.floor, highestFloor:state.highestFloor,
         inventory:state.inventory, skillsOwnedActive:state.skillsOwnedActive, skillsOwnedPassive:state.skillsOwnedPassive,
         skillSlots:state.skillSlots, passive:state.passive, aether:state.aether, settings:state.settings
       };
@@ -272,6 +274,7 @@
       try{
         const s = JSON.parse(raw);
         Object.assign(state.player,s.player||{});
+        delete state.player.atk;
         Object.assign(state.upgrades,s.upgrades||{});
         state.floor=s.floor||1; state.highestFloor=s.highestFloor||1;
         state.inventory=s.inventory||state.inventory;
@@ -364,13 +367,16 @@
       const ATK_MILE    = 0.35;
       const per   = Math.pow(1 + ATK_PER_LVL, Math.max(0, L - 1));
       const bonus = Math.pow(1 + ATK_MILE, Math.floor(Math.max(0, L - 1) / 10));
-      return Math.max(1, Math.ceil(base * per * bonus));
+      const atk = Math.max(1, Math.ceil(base * per * bonus));
+      state.player.atk = atk;
+      return atk;
     }
 
     function fmtFloor(n){ return `지하 ${n}층`; }
     function renderHud(){
+      calcAtk();
       $('#hud1').textContent = `💰 ${state.player.gold} · ✨ ${state.player.ether}`;
-      $('#hud2').textContent = `🗡️ ${calcAtk()} · 🗼 ${fmtFloor(state.floor)}`;
+      $('#hud2').textContent = `🗡️ ${state.player.atk} · 🗼 ${fmtFloor(state.floor)}`;
     }
     function renderTop(){
       renderHud();
@@ -402,7 +408,18 @@
 
     function oreUpgrade(key){ const lvl = state.upgrades.oreMul[key]||0; const cost = Math.floor(10 * Math.pow(1.6, lvl)); if((state.inventory[key]||0) < cost) { toast(`${key} x${cost} 필요`); SFX.deny(); return; } state.inventory[key]-=cost; state.upgrades.oreMul[key]=lvl+1; toast(`${key} 배율 업`); SFX.ui(); save(); refresh(); }
 
-    function renderUpgrades(){ const cont=$('#upgrades'); cont.innerHTML=''; const atkCost=Math.floor(state.upgrades.atk.baseCost*Math.pow(state.upgrades.atk.scale,state.upgrades.atk.level-1)); cont.appendChild(upgradeCard('🗡️ 공격력', `현재: ${calcAtk()} (레벨 ${state.upgrades.atk.level})`, atkCost, ()=>{ if(spend(atkCost)){ state.upgrades.atk.level++; SFX.ui(); save(); refresh(); } else SFX.deny(); })); const critCost=Math.floor(state.upgrades.crit.baseCost*Math.pow(state.upgrades.crit.scale,state.upgrades.crit.level)); cont.appendChild(upgradeCard('🎯 치명타 확률', `현재: ${(state.player.critChance*100).toFixed(1)}%`, critCost, ()=>{ if(state.player.critChance>=0.5) return toast('최대 50%'), SFX.deny(); if(spend(critCost)){ state.upgrades.crit.level++; state.player.critChance+=0.02; SFX.ui(); save(); refresh(); } else SFX.deny(); })); const spawnCost=Math.floor(state.upgrades.spawn.baseCost*Math.pow(state.upgrades.spawn.scale,state.upgrades.spawn.level)); cont.appendChild(upgradeCard('⚙️ 생성 속도', `레벨: ${state.upgrades.spawn.level}`, spawnCost, ()=>{ if(spend(spawnCost)){ state.upgrades.spawn.level++; if(state.inRun) restartSpawnTimer(); SFX.ui(); save(); refresh(); } else SFX.deny(); })); const petCost=Math.floor(state.upgrades.pet.baseCost*Math.pow(state.upgrades.pet.scale,state.upgrades.pet.level)); cont.appendChild(upgradeCard('🤖 자동채굴 펫', `보유: ${(state.upgrades.pet.level + (state.passive.petPlus||0) + (state.aether?.petPlus||0))}마리`, petCost, ()=>{ if(spend(petCost)){ state.upgrades.pet.level++; if(state.inRun) spawnPets(); SFX.ui(); save(); refresh(); } else SFX.deny(); })); }
+    function renderUpgrades(){
+      const cont=$('#upgrades'); cont.innerHTML='';
+      calcAtk();
+      const atkCost=Math.floor(state.upgrades.atk.baseCost*Math.pow(state.upgrades.atk.scale,state.upgrades.atk.level-1));
+      cont.appendChild(upgradeCard('🗡️ 공격력', `현재: ${state.player.atk} (레벨 ${state.upgrades.atk.level})`, atkCost, ()=>{ if(spend(atkCost)){ state.upgrades.atk.level++; SFX.ui(); save(); refresh(); } else SFX.deny(); }));
+      const critCost=Math.floor(state.upgrades.crit.baseCost*Math.pow(state.upgrades.crit.scale,state.upgrades.crit.level));
+      cont.appendChild(upgradeCard('🎯 치명타 확률', `현재: ${(state.player.critChance*100).toFixed(1)}%`, critCost, ()=>{ if(state.player.critChance>=0.5) return toast('최대 50%'), SFX.deny(); if(spend(critCost)){ state.upgrades.crit.level++; state.player.critChance+=0.02; SFX.ui(); save(); refresh(); } else SFX.deny(); }));
+      const spawnCost=Math.floor(state.upgrades.spawn.baseCost*Math.pow(state.upgrades.spawn.scale,state.upgrades.spawn.level));
+      cont.appendChild(upgradeCard('⚙️ 생성 속도', `레벨: ${state.upgrades.spawn.level}`, spawnCost, ()=>{ if(spend(spawnCost)){ state.upgrades.spawn.level++; if(state.inRun) restartSpawnTimer(); SFX.ui(); save(); refresh(); } else SFX.deny(); }));
+      const petCost=Math.floor(state.upgrades.pet.baseCost*Math.pow(state.upgrades.pet.scale,state.upgrades.pet.level));
+      cont.appendChild(upgradeCard('🤖 자동채굴 펫', `보유: ${(state.upgrades.pet.level + (state.passive.petPlus||0) + (state.aether?.petPlus||0))}마리`, petCost, ()=>{ if(spend(petCost)){ state.upgrades.pet.level++; if(state.inRun) spawnPets(); SFX.ui(); save(); refresh(); } else SFX.deny(); }));
+    }
     function upgradeCard(title, desc, cost, onBuy){ const wrap=document.createElement('div'); wrap.className='inv-item'; wrap.innerHTML = `<h4 style="margin:0 0 4px 0">${title}</h4><div class="mono">${desc}</div><div class="row" style="margin-top:8px;justify-content:space-between"><div class="row"><span>가격:</span> <b class="price">${cost}</b></div><button class="btn">구매</button></div>`; wrap.querySelector('.btn').addEventListener('click', onBuy); return wrap; }
     function spend(amount){ if(state.player.gold < amount){ toast('골드 부족'); return false; } state.player.gold -= amount; return true; }
     function spendAe(amount){ if(state.player.ether < amount){ toast('에테르 부족'); return false; } state.player.ether -= amount; return true; }
@@ -521,7 +538,13 @@
         case 'sonic':
           const gr = gridRect(); const cx = (gr.left+gr.right)/2, cy=(gr.top+gr.bottom)/2;
           const idx = findNearestOreIdx(cx,cy);
-          if(idx>=0){ const o=state.grid[idx]; const dmg = Math.max(20, Math.round(calcAtk()*10)); o.hp-=dmg; if(o.hp<=0){ onOreBroken(idx, o); } }
+          if(idx>=0){
+            const o=state.grid[idx];
+            const atk = calcAtk();
+            const dmg = Math.max(20, Math.round(atk*10));
+            o.hp-=dmg;
+            if(o.hp<=0){ onOreBroken(idx, o); }
+          }
           SFX.skill(); break;
       }
       setCd(key, sk.cd);
@@ -611,7 +634,8 @@
 
     function hit(idx, source='tap'){
       if(!state.inRun) return; const ore = state.grid[idx]; if(!ore) return;
-      let dmg = Math.round(calcAtk() * (state.skillAtkBuffUntil>performance.now()?2:1));
+      const atk = calcAtk();
+      let dmg = Math.round(atk * (state.skillAtkBuffUntil>performance.now()?2:1));
       const crit = (Math.random() < state.player.critChance && source==='tap');
       if(crit) dmg = Math.floor(dmg * state.player.critMult);
       ore.hp -= dmg;


### PR DESCRIPTION
## Summary
- Track computed attack separately from base and update it through `calcAtk`
- Use stored attack for HUD, upgrades, and damage calculations
- Exclude calculated attack from save data and clean it on load

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open 'package.json')*


------
https://chatgpt.com/codex/tasks/task_e_68c63eee9c3883329bccedcb70690ec6