### PR TITLE
Fix dungeon tab scroll and layout issues

### DIFF
--- a/index.html
+++ b/index.html
@@ -28,12 +28,13 @@
     .tab-btn:active{transform:scale(.98)}
     .tab-btn.active{background:var(--accent);color:#001018}
 
-    .screen{flex:1;display:flex;flex-direction:column;padding:10px 12px;gap:10px}
+    .screen{flex:1;display:flex;flex-direction:column;padding:10px 12px;gap:10px;overflow-y:auto}
     .timerbar{height:10px;background:var(--bar);border-radius:999px;overflow:hidden;border:1px solid #283058}
     .timerbar > div{height:100%;background:linear-gradient(90deg, #22c55e, #facc15);width:100%}
 
-    .grid-wrap{position:relative}
-    .grid{position:relative;background:#0e1328;padding:6px;border-radius:16px;border:1px solid #202a51;touch-action: none;height:300px;}
+    #tab-dungeon{flex:1;display:flex;flex-direction:column;overflow:hidden}
+    .grid-wrap{position:relative;flex:1;display:flex;flex-direction:column;min-height:0}
+    .grid{position:relative;background:#0e1328;padding:6px;border-radius:16px;border:1px solid #202a51;touch-action: none;flex:1}
     .ore{position:absolute;width:52px;height:52px;border-radius:10px;display:flex;align-items:center;justify-content:center;font-weight:900;color:#0a0e1e;text-shadow:0 1px 0 rgba(255,255,255,.2);}
     .ore .name{display:none}
     .hp{position:absolute;top:6px;left:6px;right:6px;height:8px;background:rgba(0,0,0,.35);border-radius:999px;border:1px solid rgba(255,255,255,.08);overflow:hidden}
@@ -338,6 +339,7 @@
     const $ = sel => document.querySelector(sel);
     const gridEl = $('#grid');
     const skillBarEl = $('#skillBar');
+    const screenEl = $('.screen');
 
     function randWeighted(items){ const total = items.reduce((a,b)=>a+b.weight,0); let r = Math.random()*total; for(const it of items){ if((r-=it.weight) <= 0) return it; } return items[0]; }
       function eligibleOresForFloor(f){
@@ -694,7 +696,10 @@
         ['dungeon','inventory','upgrades','skills','aether','settings'].forEach(id=>{
           document.querySelector('#tab-'+id).style.display = (id===t? 'block':'none');
         });
+        screenEl.scrollTop = 0;
+        screenEl.style.overflowY = t==='dungeon' ? 'hidden' : 'auto';
         renderTop();
+        if(t==='dungeon') renderGrid();
         if(t==='skills') renderSkills();
         if(t==='aether') renderAether();
         if(t==='inventory') renderInventory();


### PR DESCRIPTION
## Summary
- Reset scroll position and toggle overflow when switching tabs
- Expand dungeon grid to fill screen and prevent scrolling under banner

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c64b86ff0483328d6dcef7dd9b05fd