### PR TITLE
Reset grid cache when entering dungeon tab

### DIFF
--- a/index.html
+++ b/index.html
@@ -706,7 +706,10 @@
         screenEl.scrollTop = 0;
         screenEl.style.overflowY = t==='dungeon' ? 'hidden' : 'auto';
         renderTop();
-        if(t==='dungeon') renderGrid();
+        if(t==='dungeon'){
+          gridRectCache = null;
+          renderGrid();
+        }
         if(t==='skills') renderSkills();
         if(t==='aether') renderAether();
         if(t==='inventory') renderInventory();


### PR DESCRIPTION
## Summary
- Reset `gridRectCache` to force recalculation when opening dungeon tab

## Testing
- `npm test` (fails: Could not read package.json)


------
https://chatgpt.com/codex/tasks/task_e_68c6f91f6e048332ab392f25a7b7c1ed