### PR TITLE
Reset grid cache when run state changes

### DIFF
--- a/index.html
+++ b/index.html
@@ -565,7 +565,22 @@
     function floorHpMul(){ return 1 + 0.18*(state.floor-1); }
     function floorValMul(){ return 1 + 0.12*(state.floor-1); }
 
-    function startRun(){ if(state.inRun) return; state.inRun = true; state.etherSpawned=false; state.timeLeft = 20; state.grid = new Array(25).fill(null); for(const o of ORES){ state.loot[o.key]=0; } Object.keys(state.skillCooldowns).forEach(k=> delete state.skillCooldowns[k]); restartSpawnTimer(); state.runStartTs = performance.now(); startTick(); spawnPets(); renderSkillBar(); refresh(); }
+    function startRun(){
+      if(state.inRun) return;
+      state.inRun = true;
+      state.etherSpawned = false;
+      state.timeLeft = 20;
+      state.grid = new Array(25).fill(null);
+      for(const o of ORES){ state.loot[o.key]=0; }
+      Object.keys(state.skillCooldowns).forEach(k=> delete state.skillCooldowns[k]);
+      renderSkillBar();
+      gridRectCache = null;
+      spawnPets();
+      restartSpawnTimer();
+      state.runStartTs = performance.now();
+      startTick();
+      refresh();
+    }
 
     function startTick(){
       clearInterval(state.timers.tick);
@@ -610,7 +625,10 @@
       state.inRun=false; clearInterval(state.timers.spawn); clearInterval(state.timers.tick);
       state.pets=[]; state.lastAnimTs=0; state.grid = new Array(25).fill(null);
       if(cleared){ state.floor++; if(state.floor>state.highestFloor) state.highestFloor=state.floor; }
-      save(); refresh(); renderSkillBar();
+      renderSkillBar();
+      gridRectCache = null;
+      save();
+      refresh();
       if(cleared && state.aether?.autoAdvanceOwned && state.aether.autoAdvanceEnabled){
         setTimeout(()=>{ startRun(); }, 250);
       }


### PR DESCRIPTION
## Summary
- Reorder run start to show skill bar first and clear cached grid bounds
- Clear cached grid bounds after exiting a run to avoid leftover layout

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c6fcee76308332852a3ab69d130e9e