### PR TITLE
Reset grid cache on run start and exit

### DIFF
--- a/index.html
+++ b/index.html
@@ -565,7 +565,22 @@
     function floorHpMul(){ return 1 + 0.18*(state.floor-1); }
     function floorValMul(){ return 1 + 0.12*(state.floor-1); }
 
-    function startRun(){ if(state.inRun) return; state.inRun = true; state.etherSpawned=false; state.timeLeft = 20; state.grid = new Array(25).fill(null); for(const o of ORES){ state.loot[o.key]=0; } Object.keys(state.skillCooldowns).forEach(k=> delete state.skillCooldowns[k]); restartSpawnTimer(); state.runStartTs = performance.now(); startTick(); spawnPets(); renderSkillBar(); refresh(); }
+    function startRun(){
+      if(state.inRun) return;
+      state.inRun = true;
+      state.etherSpawned=false;
+      state.timeLeft = 20;
+      state.grid = new Array(25).fill(null);
+      for(const o of ORES){ state.loot[o.key]=0; }
+      Object.keys(state.skillCooldowns).forEach(k=> delete state.skillCooldowns[k]);
+      restartSpawnTimer();
+      state.runStartTs = performance.now();
+      startTick();
+      spawnPets();
+      renderSkillBar();
+      gridRectCache = null;
+      refresh();
+    }
 
     function startTick(){
       clearInterval(state.timers.tick);
@@ -610,7 +625,10 @@
       state.inRun=false; clearInterval(state.timers.spawn); clearInterval(state.timers.tick);
       state.pets=[]; state.lastAnimTs=0; state.grid = new Array(25).fill(null);
       if(cleared){ state.floor++; if(state.floor>state.highestFloor) state.highestFloor=state.floor; }
-      save(); refresh(); renderSkillBar();
+      save();
+      renderSkillBar();
+      gridRectCache = null;
+      refresh();
       if(cleared && state.aether?.autoAdvanceOwned && state.aether.autoAdvanceEnabled){
         setTimeout(()=>{ startRun(); }, 250);
       }


### PR DESCRIPTION
## Summary
- Reset dungeon grid cache whenever a run starts or ends to prevent shrinking

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c6fcee76308332852a3ab69d130e9e