### PR TITLE
fix: preserve dungeon grid size when switching tabs

### DIFF
--- a/index.html
+++ b/index.html
@@ -731,7 +731,6 @@
         screenEl.style.overflowY = t==='dungeon' ? 'hidden' : 'auto';
         renderTop();
         if(t==='dungeon'){
-          gridRectCache = null;
           renderGrid();
         }
         if(t==='skills') renderSkills();


### PR DESCRIPTION
## Summary
- keep cached dungeon dimensions when re-entering the dungeon tab so the grid no longer shrinks

## Testing
- `npm test` *(fails: no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c71b42eb408332beeddbd40f744ab1