### PR TITLE
Fix grid sizing after ad banner insertion

### DIFF
--- a/index.html
+++ b/index.html
@@ -357,13 +357,15 @@
     function gridRect(){
       const r = gridEl.getBoundingClientRect();
       if(r.width && r.height){
-        if(!gridRectCache){
-          gridRectCache = {left:r.left, top:r.top, width:r.width, height:r.height, right:r.right, bottom:r.bottom};
-        } else {
-          const width = Math.max(gridRectCache.width, r.width);
-          const height = Math.max(gridRectCache.height, r.height);
-          gridRectCache = {left:r.left, top:r.top, width, height, right:r.left + width, bottom:r.top + height};
+        if(gridRectCache){
+          const dx = r.left - gridRectCache.left;
+          const dy = r.top - gridRectCache.top;
+          if(dx || dy){
+            for(const ore of state.grid){ if(ore){ ore.x += dx; ore.y += dy; } }
+            for(const pet of state.pets){ pet.x += dx; pet.y += dy; }
+          }
         }
+        gridRectCache = {left:r.left, top:r.top, width:r.width, height:r.height, right:r.right, bottom:r.bottom};
       }
       return gridRectCache || {left:r.left, top:r.top, width:r.width, height:r.height, right:r.right, bottom:r.bottom};
     }


### PR DESCRIPTION
## Summary
- update gridRect to adjust existing ore and pet positions when layout shifts

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c71cd7a1b483329df57e57b41123a9