### PR TITLE
Fix pet overlap freeze

### DIFF
--- a/index.html
+++ b/index.html
@@ -1103,7 +1103,26 @@ section[id^="tab-"].active{ display:block; }
     function renderPets(){ gridEl.querySelectorAll('.pet').forEach(p=>p.remove()); const gr = gridRect(); for(const p of state.pets){ const el=document.createElement('div'); el.className='pet'; const localX = p.x - gr.left - 8; const localY = p.y - gr.top - 8; el.style.transform = `translate(${localX}px, ${localY}px)`; gridEl.appendChild(el); } }
     function findNearestOreIdx(x,y){ let best=-1, bestD=1e9; for(let i=0;i<25;i++){ const ore=state.grid[i]; if(!ore) continue; const d=Math.hypot(ore.x-x, ore.y-y); if(d<bestD){ bestD=d; best=i; } } return best; }
     function petsFrame(ts){ if(!state.inRun) return; const gr=gridRect(); const dt=Math.min(0.05,(ts-state.lastAnimTs)/1000 || 0.016); state.lastAnimTs=ts; for(const p of state.pets){ if(p.targetIdx<0 || !state.grid[p.targetIdx]) p.targetIdx = findNearestOreIdx(p.x,p.y); if(p.targetIdx>=0){ const c=cellCenter(p.targetIdx); const dx=c.x-p.x, dy=c.y-p.y; const dist=Math.hypot(dx,dy)||1; const speed = dist<28 ? PET.moveSpeed*(dist/28) : PET.moveSpeed; const steerX = (dx/dist)*speed - p.vx; const steerY = (dy/dist)*speed - p.vy; p.vx += steerX*0.12; p.vy += steerY*0.12; } else { p.vx += (Math.random()-0.5)*10*dt; p.vy += (Math.random()-0.5)*10*dt; } }
-      for(let i=0;i<state.pets.length;i++){ for(let j=i+1;j<state.pets.length;j++){ const a=state.pets[i], b=state.pets[j]; const dx=b.x-a.x, dy=b.y-a.y; const d=Math.hypot(dx,dy); const r=PET.sepRadius; if(d>0 && d<r){ const push=(r-d)/r*60; const nx=dx/d, ny=dy/d; a.vx -= nx*push; a.vy -= ny*push; b.vx += nx*push; b.vy += ny*push; } } }
+      for(let i=0;i<state.pets.length;i++){
+        for(let j=i+1;j<state.pets.length;j++){
+          const a=state.pets[i], b=state.pets[j];
+          const dx=b.x-a.x, dy=b.y-a.y;
+          const d=Math.hypot(dx,dy);
+          const r=PET.sepRadius;
+          if(d<r){
+            const push=(r-(d||0))/r*60;
+            let nx, ny;
+            if(d>0){
+              nx=dx/d; ny=dy/d;
+            }else{
+              const ang=Math.random()*Math.PI*2;
+              nx=Math.cos(ang); ny=Math.sin(ang);
+            }
+            a.vx -= nx*push; a.vy -= ny*push;
+            b.vx += nx*push; b.vy += ny*push;
+          }
+        }
+      }
       for(const p of state.pets){ p.x += p.vx*dt; p.y += p.vy*dt; p.x = Math.max(gr.left+8, Math.min(gr.right-8, p.x)); p.y = Math.max(gr.top+8, Math.min(gr.bottom-8, p.y)); if(p.targetIdx>=0){ const c=cellCenter(p.targetIdx); const dist=Math.hypot(c.x-p.x, c.y-p.y); p.cd -= dt; if(dist<=PET.atkRange && p.cd<=0){ p.cd = PET.atkInterval; hit(p.targetIdx,'pet'); } } }
       renderPets(); requestAnimationFrame(petsFrame); }
 


### PR DESCRIPTION
## Summary
- ensure pet separation logic resolves collisions even when pets are perfectly overlapping
- randomize push direction to prevent stuck pets while keeping avoidance behavior intact

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ce6989df948332bcfd7f3c2a92dc11