### PR TITLE
Auto upgrade ore sales and display multipliers

### DIFF
--- a/index.html
+++ b/index.html
@@ -436,6 +436,7 @@ section[id^="tab-"].active{ display:block; }
       floor: 1,
       highestFloor: 1,
       inventory: {},
+      oreSales: {},
       loot: {},
       grid: new Array(25).fill(null),
       inRun:false,
@@ -470,7 +471,7 @@ section[id^="tab-"].active{ display:block; }
         __version: VERSION,
         player: restPlayer,
         upgrades:state.upgrades, floor:state.floor, highestFloor:state.highestFloor,
-        inventory:state.inventory, skillsOwnedActive:state.skillsOwnedActive, skillsOwnedPassive:state.skillsOwnedPassive,
+        inventory:state.inventory, oreSales:state.oreSales, skillsOwnedActive:state.skillsOwnedActive, skillsOwnedPassive:state.skillsOwnedPassive,
         skillSlots:state.skillSlots, passive:state.passive, aether:state.aether, settings:state.settings
       };
       try{ localStorage.setItem(SAVE_KEY, JSON.stringify(payload)); }catch(e){ console.warn('save failed', e); }
@@ -500,6 +501,7 @@ section[id^="tab-"].active{ display:block; }
         }
         state.floor=s.floor||1; state.highestFloor=s.highestFloor||1;
         state.inventory=s.inventory||state.inventory;
+        state.oreSales = s.oreSales || state.oreSales;
         state.skillsOwnedActive=s.skillsOwnedActive||{};
         state.skillsOwnedPassive=s.skillsOwnedPassive||{};
         state.skillSlots=s.skillSlots||[null,null,null,null,null];
@@ -532,7 +534,12 @@ section[id^="tab-"].active{ display:block; }
     // ---------- Ores ----------
     // 데이터는 data/probabilities.js에서 로드됩니다.
 
-    for(const o of ORES){ state.inventory[o.key]=state.inventory[o.key]||0; state.loot[o.key]=0; state.upgrades.oreMul[o.key]=state.upgrades.oreMul[o.key]||0; }
+    for(const o of ORES){
+      state.inventory[o.key]=state.inventory[o.key]||0;
+      state.loot[o.key]=0;
+      state.upgrades.oreMul[o.key]=state.upgrades.oreMul[o.key]||0;
+      state.oreSales[o.key]=state.oreSales[o.key]||0;
+    }
 
     const PET = { moveSpeed: 220, atkInterval: 0.55, sepRadius: 24, atkRange: 18 };
 
@@ -817,11 +824,54 @@ section[id^="tab-"].active{ display:block; }
     function cellCenter(idx){ const o = state.grid[idx]; return { x:o.x, y:o.y }; }
     function oreIndexFromPoint(x,y){ const gr = gridRect(); const localX = x - gr.left; const localY = y - gr.top; if(localX<0 || localY<0 || localX>gr.width || localY>gr.height) return -1; for(let i=0;i<25;i++){ const o=state.grid[i]; if(!o) continue; const h=ORE_RADIUS; if(localX>=o.x-h && localX<=o.x+h && localY>=o.y-h && localY<=o.y+h) return i; } return -1; }
 
+    function oreLevel(key){
+      return state.upgrades.oreMul[key]||0;
+    }
+
+    function levelMultiplier(level){
+      return 1 + Math.max(0, level) * 0.01;
+    }
+
+    function formatMultiplier(mult){
+      const str = mult.toFixed(2);
+      const num = parseFloat(str);
+      return Number.isFinite(num) ? num.toString() : str;
+    }
+
     function sellMultiplier(key){
-      const lvl = state.upgrades.oreMul[key]||0;
-      const upgMul = Math.pow(1.2, lvl);
+      const lvl = oreLevel(key);
+      const upgMul = levelMultiplier(lvl);
       const passiveMul = 1 + (state.passive.sellBonus||0);
       return upgMul * passiveMul;
+    }
+
+    function processOreSale(key, amount, baseValue){
+      if(!key || amount<=0 || !Number.isFinite(baseValue)) return 0;
+      const oreInfo = ORE_BY_KEY.get(key);
+      const passiveMul = 1 + (state.passive.sellBonus||0);
+      let sold = state.oreSales[key]||0;
+      let level = oreLevel(key);
+      const prevLevel = level;
+      let remaining = amount;
+      let gold = 0;
+      while(remaining>0){
+        const nextThreshold = (Math.floor(sold/10)+1)*10;
+        const batch = Math.min(remaining, Math.max(1, nextThreshold - sold));
+        const lvlMul = levelMultiplier(level);
+        gold += batch * baseValue * lvlMul * passiveMul;
+        sold += batch;
+        remaining -= batch;
+        if(sold % 10 === 0){
+          level += 1;
+        }
+      }
+      state.oreSales[key] = sold;
+      state.upgrades.oreMul[key] = level;
+      if(level !== prevLevel){
+        const oreName = oreInfo?.name || key;
+        toast(`${oreName} 레벨 ${level}`);
+      }
+      return Math.round(gold);
     }
 
     function calcCritChance(){
@@ -872,16 +922,72 @@ section[id^="tab-"].active{ display:block; }
 
     function renderInventory(){ const box=$('#inventoryList'); box.innerHTML='';
       const chk = document.getElementById('autoSellChkInv'); if(chk){ chk.checked = !!state.settings.autoSell; chk.onchange = ()=>{ state.settings.autoSell = !!chk.checked; save(); toast(`자동판매 ${chk.checked?'ON':'OFF'}`); }; }
-      for(const t of ORES){ const inv = state.inventory[t.key]||0; const mul=sellMultiplier(t.key); const li=document.createElement('div'); li.className='inv-item'; li.innerHTML = `<h4>${t.name} <span class="small">(${t.key})</span></h4><div>가치: <span class="price">${Math.round(t.value*mul)}</span> 골드</div><div class="row" style="margin-top:6px;gap:6px;flex-wrap:wrap"><button class="btn secondary" data-sellall="${t.key}">모두 판매</button><button class="btn secondary" data-sell="${t.key}">1개 판매</button><button class="btn" data-upg-ore="${t.key}">업그레이드</button></div><div class="row" style="margin-top:6px"><div class="mono">보유: ${inv}</div></div>`; box.appendChild(li);} 
-      box.querySelectorAll('[data-sell]').forEach(btn=> btn.addEventListener('click', ()=>{ SFX.ui(); const k=btn.dataset.sell; const t=ORES.find(o=>o.key===k); if(state.inventory[k]>0){ state.inventory[k]--; state.player.gold+=Math.round(t.value*sellMultiplier(k)); save(); refresh(); }}));
+      for(const t of ORES){
+        const inv = state.inventory[t.key]||0;
+        const lvl = oreLevel(t.key);
+        const levelMul = levelMultiplier(lvl);
+        const totalMul = sellMultiplier(t.key);
+        const li=document.createElement('div');
+        li.className='inv-item';
+        li.innerHTML = `<h4>${t.name} <span class="small">(${t.key})</span></h4>`+
+          `<div class="mono">레벨: ${lvl}</div>`+
+          `<div class="mono">판매 금액: x${formatMultiplier(levelMul)}</div>`+
+          `<div>가치: <span class="price">${Math.round(t.value*totalMul)}</span> 골드</div>`+
+          `<div class="row" style="margin-top:6px;gap:6px;flex-wrap:wrap">`+
+            `<button class="btn secondary" data-sellall="${t.key}">모두 판매</button>`+
+            `<button class="btn secondary" data-sell="${t.key}">1개 판매</button>`+
+          `</div>`+
+          `<div class="row" style="margin-top:6px"><div class="mono">보유: ${inv}</div></div>`;
+        box.appendChild(li);
+      }
+      box.querySelectorAll('[data-sell]').forEach(btn=> btn.addEventListener('click', ()=>{
+        const k=btn.dataset.sell;
+        const t=ORES.find(o=>o.key===k);
+        if(state.inventory[k]>0){
+          SFX.ui();
+          state.inventory[k]--;
+          const gained = processOreSale(k,1,t.value);
+          if(gained>0){
+            state.player.gold+=gained;
+          }
+          save();
+          refresh();
+        }
+      }));
       box.querySelectorAll('[data-sellall]').forEach(btn=> btn.addEventListener('click', ()=>{ SFX.ui(); sellAllOf(btn.dataset.sellall); }));
-      box.querySelectorAll('[data-upg-ore]').forEach(btn=> btn.addEventListener('click', ()=>{ SFX.ui(); oreUpgrade(btn.dataset.upgOre)}));
       $('#sellAllGlobal').onclick = ()=>{ SFX.ui(); sellAllOres(); };
     }
-    function sellAllOf(key){ const t=ORES.find(o=>o.key===key); const n=state.inventory[key]||0; if(n>0){ state.inventory[key]=0; state.player.gold+=Math.round(n*t.value*sellMultiplier(key)); save(); refresh(); } }
-    function sellAllOres(){ let total=0; for(const t of ORES){ const n=state.inventory[t.key]||0; if(n>0){ total += n*t.value*sellMultiplier(t.key); state.inventory[t.key]=0; } } if(total>0){ state.player.gold += Math.round(total); save(); refresh(); } }
-
-    function oreUpgrade(key){ const lvl = state.upgrades.oreMul[key]||0; const cost = Math.floor(10 * Math.pow(1.6, lvl)); if((state.inventory[key]||0) < cost) { toast(`${key} x${cost} 필요`); SFX.deny(); return; } state.inventory[key]-=cost; state.upgrades.oreMul[key]=lvl+1; toast(`${key} 배율 업`); SFX.ui(); save(); refresh(); }
+    function sellAllOf(key){
+      const t=ORES.find(o=>o.key===key);
+      const n=state.inventory[key]||0;
+      if(n>0){
+        state.inventory[key]=0;
+        const gained = processOreSale(key, n, t.value);
+        if(gained>0){
+          state.player.gold+=gained;
+        }
+        save();
+        refresh();
+      }
+    }
+    function sellAllOres(){
+      let total=0;
+      for(const t of ORES){
+        const n=state.inventory[t.key]||0;
+        if(n>0){
+          const gained = processOreSale(t.key, n, t.value);
+          if(gained>0){
+            total += gained;
+          }
+          state.inventory[t.key]=0;
+        }
+      }
+      if(total>0){
+        state.player.gold += total;
+        save();
+        refresh();
+      }
+    }
 
     function renderUpgrades(){
       const cont=$('#upgrades'); cont.innerHTML='';
@@ -1110,7 +1216,10 @@ section[id^="tab-"].active{ display:block; }
           const oreDef = ORES.find(o=>o.key===k);
           const n = state.loot[k]||0;
           if(!oreDef || n<=0) continue;
-          totalGold += Math.round(n * oreDef.value * sellMultiplier(k));
+          const gained = processOreSale(k, n, oreDef.value);
+          if(gained>0){
+            totalGold += gained;
+          }
         }
         if(totalGold>0) state.player.gold += totalGold;
       } else {


### PR DESCRIPTION
## Summary
- track ore sales to automatically raise ore levels after every 10 items sold and remove the manual upgrade button
- show each ore's level and level-based sale multiplier in the inventory and use it when pricing sales
- persist ore sale counts, apply the new auto-upgrade flow to bulk/auto sells, and update saves accordingly

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d88ebc33c88332a953d0fe1d224ee2