### PR TITLE
Remove pet overlap avoidance logic

### DIFF
--- a/index.html
+++ b/index.html
@@ -1472,26 +1472,6 @@ section[id^="tab-"].active{ display:block; }
       return false;
     }
     function petsFrame(ts){ if(!state.inRun) return; const gr=gridRect(); const dt=Math.min(0.05,(ts-state.lastAnimTs)/1000 || 0.016); state.lastAnimTs=ts; for(const p of state.pets){ if(p.swinging){ const ore = state.grid[p.targetIdx]; if(!ore){ p.swinging=false; p.targetIdx=-1; } continue; } if(p.targetIdx<0 || !state.grid[p.targetIdx]) p.targetIdx = findNearestOreIdx(p.x,p.y); if(p.targetIdx>=0){ const ore = state.grid[p.targetIdx]; if(!ore){ p.targetIdx=-1; continue; } const c=cellCenter(p.targetIdx); const dx=c.x-p.x, dy=c.y-p.y; const dist=Math.hypot(dx,dy)||1; const speed = dist<28 ? PET.moveSpeed*(dist/28) : PET.moveSpeed; const steerX = (dx/dist)*speed - p.vx; const steerY = (dy/dist)*speed - p.vy; p.vx += steerX*0.12; p.vy += steerY*0.12; } else { p.vx += (Math.random()-0.5)*10*dt; p.vy += (Math.random()-0.5)*10*dt; } }
-      for(let i=0;i<state.pets.length;i++){
-        for(let j=i+1;j<state.pets.length;j++){
-          const a=state.pets[i], b=state.pets[j];
-          const dx=b.x-a.x, dy=b.y-a.y;
-          const d=Math.hypot(dx,dy);
-          const r=PET.sepRadius;
-          if(d<r){
-            const push=(r-(d||0))/r*60;
-            let nx, ny;
-            if(d>0){
-              nx=dx/d; ny=dy/d;
-            }else{
-              const ang=Math.random()*Math.PI*2;
-              nx=Math.cos(ang); ny=Math.sin(ang);
-            }
-            a.vx -= nx*push; a.vy -= ny*push;
-            b.vx += nx*push; b.vy += ny*push;
-          }
-        }
-      }
       for(const p of state.pets){
         const ore = p.targetIdx>=0 ? state.grid[p.targetIdx] : null;
         if(p.swinging){


### PR DESCRIPTION
## Summary
- remove the pet separation loop so pets can overlap while moving

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d89c123580833299590a874664edd2