### PR TITLE
Refactor attack multiplier constants into shared helper

### DIFF
--- a/data/upgrades.js
+++ b/data/upgrades.js
@@ -15,6 +15,24 @@ function spawnIntervalForLevel(level = 0) {
 
 window.spawnIntervalForLevel = spawnIntervalForLevel;
 
+const ATK_GROWTH = {
+  perLevel: 0.12,
+  milestoneBonus: 0.35,
+  milestoneStep: 10,
+};
+
+window.ATK_GROWTH = ATK_GROWTH;
+
+function computeAtkMultiplier(level = 0) {
+  const lvl = Math.max(0, Math.floor(level));
+  const per = Math.pow(1 + ATK_GROWTH.perLevel, lvl);
+  const bonusCount = Math.floor(lvl / ATK_GROWTH.milestoneStep);
+  const bonus = Math.pow(1 + ATK_GROWTH.milestoneBonus, bonusCount);
+  return per * bonus;
+}
+
+window.computeAtkMultiplier = computeAtkMultiplier;
+
 const UPGRADE_CONFIG = {
   atk: {
     defaultLevel: 0,
@@ -93,11 +111,8 @@ function previewAtk(state, level){
   const baseFloor = 10 + ownedPower;
   const storedBase = typeof state?.player?.atkBase === 'number' ? state.player.atkBase : 10;
   const base = Math.max(storedBase, baseFloor);
-  const ATK_PER_LVL = 0.12;
-  const ATK_MILE = 0.35;
-  const per = Math.pow(1 + ATK_PER_LVL, Math.max(0, lvl));
-  const bonus = Math.pow(1 + ATK_MILE, Math.floor(Math.max(0, lvl) / 10));
-  return Math.max(1, Math.ceil(base * per * bonus));
+  const multiplier = computeAtkMultiplier(lvl);
+  return Math.max(1, Math.ceil(base * multiplier));
 }
 
 function previewCritChance(state, level){

--- a/index.html
+++ b/index.html
@@ -1169,11 +1169,18 @@ section[id^="tab-"].active{ display:block; }
       const storedBase = (typeof state.player.atkBase === 'number') ? state.player.atkBase : 10;
       const base = Math.max(storedBase, baseFloor);
       state.player.atkBase = base;
-      const ATK_PER_LVL = 0.12;
-      const ATK_MILE    = 0.35;
-      const per   = Math.pow(1 + ATK_PER_LVL, Math.max(0, L));
-      const bonus = Math.pow(1 + ATK_MILE, Math.floor(Math.max(0, L) / 10));
-      const atk = Math.max(1, Math.ceil(base * per * bonus));
+      const fallbackMultiplier = () => {
+        const perLevel = 0.12;
+        const milestoneBonus = 0.35;
+        const milestoneStep = 10;
+        const per = Math.pow(1 + perLevel, Math.max(0, L));
+        const bonus = Math.pow(1 + milestoneBonus, Math.floor(Math.max(0, L) / milestoneStep));
+        return per * bonus;
+      };
+      const multiplier = typeof window.computeAtkMultiplier === 'function'
+        ? window.computeAtkMultiplier(L)
+        : fallbackMultiplier();
+      const atk = Math.max(1, Math.ceil(base * multiplier));
       state.player.atk = atk;
       calcCritChance();
       return atk;


### PR DESCRIPTION
## Summary
- centralize the attack upgrade growth constants in `data/upgrades.js`
- expose a shared multiplier helper so preview and runtime attack math use the same source

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68da32e93b2c83329bc7f6b2e54d48a6