### PR TITLE
Remove haste status note from spawn speed description

### DIFF
--- a/data/upgrades.js
+++ b/data/upgrades.js
@@ -214,10 +214,7 @@ window.UPGRADE_INFO = [
           : current;
         const diff = Math.abs(active - current);
         if(diff > 1){
-          const hasteNote = state?.runFlags?.hasteActive ? ', 가속 효과 적용중' : '';
-          desc += ` (실제: ${formatSeconds(active)}초${hasteNote})`;
-        } else if(state?.runFlags?.hasteActive){
-          desc += ' (가속 효과 적용중)';
+          desc += ` (실제: ${formatSeconds(active)}초)`;
         }
       }
       return desc;


### PR DESCRIPTION
## Summary
- remove the haste active text from the spawn speed upgrade description while preserving the actual interval display

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68da809f12d88332854690dd782ba791