### PR TITLE
Adjust meteor and sonic skill cooldowns

### DIFF
--- a/data/skills.js
+++ b/data/skills.js
@@ -1,10 +1,48 @@
 // Active and passive skill definitions
 window.ACTIVE_SKILL_DATA = [
-  { key:'berserk',  name:'광폭화',   desc:'5초간 공격력 x2',         ae:50,  cd:20 },
-  { key:'timewarp', name:'타임워프', desc:'시간 +3초',              ae:120, cd:20, autoToggleKey:'autoTimewarp', autoToggleLabel:'자동 사용' },
-  { key:'meteor',   name:'운석 낙하', desc:'모든 광석에 큰 피해',    ae:200, cd:30 },
-  { key:'haste',    name:'가속',     desc:'5초간 생성 속도 2배',     ae:140, cd:20, autoToggleKey:'autoHaste', autoToggleLabel:'자동 사용' },
-  { key:'sonic',    name:'초음파',   desc:'가까운 광석에 즉시 큰 피해', ae:130, cd:18 },
+  {
+    key:'berserk',
+    name:'광폭화',
+    desc:'5초간 공격력 x2',
+    ae:50,
+    cd:20,
+  },
+  {
+    key:'timewarp',
+    name:'타임워프',
+    desc:'시간 +3초',
+    ae:120,
+    cd:20,
+    autoToggleKey:'autoTimewarp',
+    autoToggleLabel:'자동 사용',
+  },
+  {
+    key:'meteor',
+    name:'운석 낙하',
+    desc:'모든 광석에 큰 피해',
+    ae:200,
+    cd:15,
+    autoToggleKey:'autoMeteor',
+    autoToggleLabel:'자동 사용',
+  },
+  {
+    key:'haste',
+    name:'가속',
+    desc:'5초간 생성 속도 2배',
+    ae:140,
+    cd:20,
+    autoToggleKey:'autoHaste',
+    autoToggleLabel:'자동 사용',
+  },
+  {
+    key:'sonic',
+    name:'초음파',
+    desc:'가까운 광석에 즉시 큰 피해',
+    ae:130,
+    cd:15,
+    autoToggleKey:'autoSonic',
+    autoToggleLabel:'자동 사용',
+  },
 ];
 
 window.PASSIVE_SKILL_DATA = [


### PR DESCRIPTION
## Summary
- lower meteor and sonic active skill cooldowns to 15 seconds
- enable auto-use toggles for meteor and sonic skills so players can automate them

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68da85391b108332b2ddda0e77a1ab3d