### PR TITLE
Remove ore death sound effect

### DIFF
--- a/index.html
+++ b/index.html
@@ -598,7 +598,7 @@ section[id^="tab-"].active{ display:block; }
         const played = await playOreHit(0.75);
         if(!played) beep(900,0.05,'square',0.045);
       },
-      break(){ beep(240,0.07,'sawtooth',0.05); },
+      break(){},
       skill(){ beep(700,0.08,'triangle',0.05); },
       deny(){ beep(180,0.12,'square',0.04); },
       ui(){ beep(430,0.05,'triangle',0.035); }


### PR DESCRIPTION
## Summary
- disable the ore break sound effect so ore destruction is silent

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68daa55e4ea48332810cb0d9dae7dde9