### PR TITLE
Raise dimensional pet cap to seven

### DIFF
--- a/data/aether.js
+++ b/data/aether.js
@@ -18,7 +18,7 @@ window.REBIRTH_PERK_DATA = [
     desc: '특별 펫 +1',
     base: 48,
     scale: 1.8,
-    max: 5,
+    max: 7,
     getLevel: (state) => state.aether.petPlus || 0,
     apply: ({ state }) => {
       state.aether.petPlus = (state.aether.petPlus || 0) + 1;

--- a/index.html
+++ b/index.html
@@ -892,6 +892,8 @@ section[id^="tab-"].active{ display:block; }
       { bg:'#facc15', border:'#a16207', glow:'rgba(250,204,21,0.75)' },
       { bg:'#22c55e', border:'#15803d', glow:'rgba(34,197,94,0.75)' },
       { bg:'#3b82f6', border:'#1d4ed8', glow:'rgba(59,130,246,0.75)' },
+      { bg:'#4338ca', border:'#312e81', glow:'rgba(99,102,241,0.8)' },
+      { bg:'#a855f7', border:'#7c3aed', glow:'rgba(168,85,247,0.82)' },
     ];
 
     const $ = sel => document.querySelector(sel);


### PR DESCRIPTION
## Summary
- increase the Dimensional Pet rebirth perk cap to level 7
- add new indigo and purple special pet styles for the newly unlocked levels

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dcc023bb5483328ebba846fc469f60