### PR TITLE
Limit smart pet upgrade to effective max level

### DIFF
--- a/index.html
+++ b/index.html
@@ -925,7 +925,11 @@ section[id^="tab-"].active{ display:block; }
           const saved = savedUpgrades[key];
           const lvl = typeof saved === 'number' ? saved
             : (saved && typeof saved.level === 'number' ? saved.level : def.level || 0);
-          state.upgrades[key] = { level: Math.max(0, lvl) };
+          const normalized = Math.max(0, lvl);
+          const clamped = typeof clampUpgradeLevelToConfig === 'function'
+            ? clampUpgradeLevelToConfig(key, normalized)
+            : normalized;
+          state.upgrades[key] = { level: clamped };
         }
         state.floor=s.floor||1; state.highestFloor=s.highestFloor||1;
         state.inventory=s.inventory||state.inventory;
@@ -1083,7 +1087,10 @@ section[id^="tab-"].active{ display:block; }
     const GRID_SAFE_MARGIN = 6;
 
     function applyPetBehaviorUpgrade(){
-      const level = getUpgradeLevel(state, 'petAi');
+      const rawLevel = getUpgradeLevel(state, 'petAi');
+      const level = typeof clampPetBehaviorLevel === 'function'
+        ? clampPetBehaviorLevel(rawLevel)
+        : rawLevel;
       let stats = null;
       if(typeof computePetBehaviorStats === 'function'){
         try {


### PR DESCRIPTION
## Summary
- compute the smart pet AI upgrade's effective cap from its stat growth limits and reuse it when clamping levels
- update the upgrade UI, purchasing logic, and saved-data loading to respect the derived maximum level and surface messaging when capped
- expose clamping helpers so pet behavior updates and other systems always use the bounded level

## Testing
- node - <<'NODE'


------
https://chatgpt.com/codex/tasks/task_e_68dd2076f72883328b8e50a77d2ca8c5